### PR TITLE
Add cpu inference option

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,6 +234,9 @@ echo "Hey, how are you?" | python scripts/tts_pytorch.py - -
 
 # From text file to audio file
 python scripts/tts_pytorch.py text_to_say.txt audio_output.wav
+
+# Use --cpu flag for CPU-only inference
+python scripts/tts_pytorch.py --cpu text_to_say.txt audio_output.wav
 ```
 
 This requires the [moshi package](https://pypi.org/project/moshi/), which can be installed via pip.

--- a/scripts/tts_pytorch.py
+++ b/scripts/tts_pytorch.py
@@ -44,12 +44,26 @@ def main():
         help="The voice to use, relative to the voice repo root. "
         f"See {DEFAULT_DSM_TTS_VOICE_REPO}",
     )
+    parser.add_argument(
+        "--cpu",
+        action="store_true",
+        help="Use CPU instead of GPU for inference",
+    )
     args = parser.parse_args()
 
     print("Loading model...")
     checkpoint_info = CheckpointInfo.from_hf_repo(args.hf_repo)
+
+    # Set device and precision
+    if args.cpu:
+        device = torch.device("cpu")
+        dtype = torch.float32
+    else:
+        device = torch.device("cuda")
+        dtype = torch.bfloat16
+
     tts_model = TTSModel.from_checkpoint_info(
-        checkpoint_info, n_q=32, temp=0.6, device=torch.device("cuda")
+        checkpoint_info, n_q=32, temp=0.6, device=device, dtype=dtype
     )
 
     if args.inp == "-":


### PR DESCRIPTION
## Checklist

- [x] Read CONTRIBUTING.md, and accept the CLA by including the provided snippet. We will not accept PR without this.
> I, Sematre, confirm that I have read and understood the terms of the CLA of Kyutai-labs, as outlined in the repository's CONTRIBUTING.md, and I agree to be bound by these terms.
- [x] Run pre-commit hook.
- [ ] If you changed Rust code, run `cargo check`, `cargo clippy`, `cargo test`.

## PR Description

Add `--cpu` option to TTS PyTorch script for CPU-only inference. This allows users without GPU hardware to run the model using CPU with appropriate dtype (float32 instead of half precision).

Performance on AMD Ryzen 7 5800X (using 8 threads, DDR4-3600): ~3.8 characters/second inference speed.

### Reproduction steps
```sh
python3.12 -m venv venv
source venv/bin/activate
pip install torch==2.6.0 --index-url https://download.pytorch.org/whl/cpu
pip install moshi huggingface-hub

python scripts/tts_pytorch.py --cpu text_to_say.txt audio_output.wav
```

### Changes
- Added `--cpu` argument flag to `scripts/tts_pytorch.py`
- Updated device and dtype selection logic (CPU uses float32, GPU uses half precision)
- Updated README.md with usage example