### PR TITLE
Fix: Corrected NotImplementedError in tts_pytorch.ipynb

### DIFF
--- a/tts_pytorch.ipynb
+++ b/tts_pytorch.ipynb
@@ -81,7 +81,7 @@
     "pcms = []\n",
     "def _on_frame(frame):\n",
     "    print(\"Step\", len(pcms), end=\"\\r\")\n",
-    "    if (frame != -1).all():\n",
+    "    if (frame != -1).all().item():\n",
     "        pcm = tts_model.mimi.decode(frame[:, 1:, :]).cpu().numpy()\n",
     "        pcms.append(np.clip(pcm[0, 0], -1, 1))\n",
     "\n",


### PR DESCRIPTION
In tts_pytorch.ipynb, I found a potential error. The line if (frame !=-1).all(): is likely to cause a NotImplementedError because the all() method is not implemented for torch.Tensor in the way it's being used here. It should be (frame != -1).all().item().