### PR TITLE
Use inferred word as print instead of previous word

### DIFF
--- a/stt-rs/src/main.rs
+++ b/stt-rs/src/main.rs
@@ -204,10 +204,10 @@ impl Model {
                             print!(" {word}");
                             std::io::stdout().flush()?
                         } else {
+                            last_word = Some((word, *start_time));
                             if let Some((word, prev_start_time)) = last_word.take() {
                                 println!("[{prev_start_time:5.2}-{start_time:5.2}] {word}");
                             }
-                            last_word = Some((word, *start_time));
                         }
                     }
                 }


### PR DESCRIPTION
Currently the word that is printed at time t is the one from the previous iteration making it just one iteration slow. 

This should fix it although I'm not exactly sure why it used to be as is before.

## Checklist

- [x] Read CONTRIBUTING.md, and accept the CLA by including the provided snippet. We will not accept PR without this.
- [x] Run pre-commit hook.
- [x] If you changed Rust code, run `cargo check`, `cargo clippy`, `cargo test`.

## PR Description

I, @haixuantao, confirm that I have read and understood the terms of the CLA of Kyutai-labs, as outlined in the repository's CONTRIBUTING.md, and I agree to be bound by these terms.