### PR TITLE
Refactor frame callback to remove last_time tracking

### DIFF
--- a/scripts/tts_pytorch.py
+++ b/scripts/tts_pytorch.py
@@ -117,6 +117,7 @@ def main():
                     break
                 time.sleep(1)
     else:
+
         def _on_frame(frame):
             nonlocal _frames_cnt
             nonlocal last_time


### PR DESCRIPTION
Removed unnecessary time tracking in the frame callback.

## Checklist

- [ ] Read CONTRIBUTING.md, and accept the CLA by including the provided snippet. We will not accept PR without this.
- [ ] Run pre-commit hook.
- [ ] If you changed Rust code, run `cargo check`, `cargo clippy`, `cargo test`.

## PR Description

<!-- Description for the PR -->
