### PR TITLE
No sound played without this fix on window

### DIFF
--- a/scripts/tts_pytorch_streaming.py
+++ b/scripts/tts_pytorch_streaming.py
@@ -217,12 +217,15 @@ def main():
 
         gen = TTSGen(tts_model, [condition_attributes], on_frame=_on_frame)
 
-        with sd.OutputStream(
-            samplerate=tts_model.mimi.sample_rate,
-            blocksize=1920,
-            channels=1,
-            callback=audio_callback,
-        ) and tts_model.mimi.streaming(1):
+        with (
+            sd.OutputStream(
+                samplerate=tts_model.mimi.sample_rate,
+                blocksize=1920,
+                channels=1,
+                callback=audio_callback,
+            ),
+            tts_model.mimi.streaming(1),
+        ):
             first_turn = True
             for line in sys.stdin:
                 entries = prepare_script(tts_model, line.strip(), first_turn=first_turn)


### PR DESCRIPTION
(pre-commit hook done)

## Checklist

- [ X ] Read CONTRIBUTING.md, and accept the CLA by including the provided snippet. We will not accept PR without this.
- [ X ] Run pre-commit hook.
- [ X ] If you changed Rust code, run `cargo check`, `cargo clippy`, `cargo test`.

## PR Description

Hello,

I'm not sur at all it will be helpfull for you because I'm on window.
(I replace "triton" lib by "triton-windows" from pypi)

I notice this bug that prevent me to ear any sound in the tts_pytorch_streaming.py example.
So I would like to share it. I hope it will help.

Here is a "more readable" content of the fix (before pre-hook git commit and ruff formatter): 
<img width="565" height="99" alt="image" src="https://github.com/user-attachments/assets/a00b370e-1ec5-4481-a8d2-6bb1ae5cd1e5" />


Notes:
 - I find the problem with the help from claude sonnet 4.5 using github copilot
 - I'm not an expert in Python devs
 - I didn't change anything on RUST code so I don't run  `cargo check`, `cargo clippy`, `cargo test`.


<!-- Description for the PR -->
