### PR TITLE
tts_pytorch_streaming: skip depformer during the delay region (~2x faster time-to-first-audio)

### DIFF
--- a/scripts/tts_pytorch_streaming.py
+++ b/scripts/tts_pytorch_streaming.py
@@ -113,6 +113,18 @@ class TTSGen:
         )
         self.lm_gen.streaming_forever(1)
 
+        # While offset < delay_steps the audio tokens are force-zeroed by
+        # _on_audio_hook anyway, so the depformer pass can be skipped
+        # entirely for those steps (same optimization as
+        # TTSModel.generate). Skipping it roughly halves
+        # time-to-first-audio.
+        self._no_dep_tokens = torch.full(
+            (1, tts_model.lm.dep_q, 1),
+            tts_model.machine.token_ids.zero,
+            dtype=torch.long,
+            device=tts_model.lm.device,
+        )
+
     def process_last(self):
         while len(self.state.entries) > 0 or self.state.end_step is not None:
             self._step()
@@ -134,7 +146,12 @@ class TTSGen:
             dtype=torch.long,
             device=self.tts_model.lm.device,
         )
-        frame = self.lm_gen.step(input_tokens)
+        depformer_replace_tokens = None
+        if self.offset < self.tts_model.delay_steps:
+            depformer_replace_tokens = self._no_dep_tokens
+        frame = self.lm_gen.step(
+            input_tokens, depformer_replace_tokens=depformer_replace_tokens
+        )
         self.offset += 1
         if frame is not None:
             if self.on_frame is not None:


### PR DESCRIPTION
> Note from a human: this fix is outside my area of experience — it came out of Claude (Fable 5) optimising the voice pipeline on my own home setup, and the patch, benchmarks, and this PR text are entirely its work ("vibe coded", verified by tests and my own use). Review accordingly.

`TTSModel.generate` skips the depformer while `offset < self.delay_steps` by passing `depformer_replace_tokens` (`moshi/models/tts.py`), since `_on_audio_hook` force-zeroes those steps' audio tokens regardless of what the depformer produces. The streaming script's `TTSGen` never got the same treatment, so it runs the full depformer (~`delay_steps` × `dep_q` passes) before the first audible frame can exist.

This PR applies the identical optimisation to `tts_pytorch_streaming.py`. Output is unchanged by construction — the skipped computation's results were being overwritten with `token_ids.zero` anyway.

Measured (tts-1.6b-en_fr, n_q=16, bf16, single utterance, warm): per-step cost during the delay region 34 ms → 11 ms; time-to-first-audio 660 ms → 276 ms. Numbers are from an Intel Arc B580 via torch-XPU, but the win is backend-independent — it removes ~16 depformer passes whatever the device. Sanity-checked by transcribing the patched script's output with whisper-large-v3 (word-perfect).
